### PR TITLE
Improve randomized indexing in replacement table mutators

### DIFF
--- a/gecko/_dfbitlookup.py
+++ b/gecko/_dfbitlookup.py
@@ -122,3 +122,29 @@ def count_bits_per_index(df: pd.DataFrame, capacity: _t.Optional[int] = None) ->
             raise ValueError(f"capacity must not be higher than {max_df_capacity}, is {capacity}")
 
     return list((idx, test_index(df, idx).sum()) for idx in range(capacity))
+
+
+def count_bits_per_row(df: pd.DataFrame, capacity: _t.Optional[int] = None) -> pd.Series:
+    max_df_capacity = int(_UINT_CAPACITY * len(df.columns))
+
+    if capacity is None:
+        capacity = max_df_capacity
+    else:
+        capacity = int(capacity)
+
+        if capacity <= 0:
+            raise ValueError(f"capacity must be positive, is {capacity}")
+
+        if capacity > max_df_capacity:
+            raise ValueError(f"capacity must not be higher than {max_df_capacity}, is {capacity}")
+
+    srs_count = pd.Series(
+        np.zeros(len(df), dtype=np.uint32),
+        copy=False,
+        index=df.index,
+    )
+
+    for idx in range(capacity):
+        srs_count[test_index(df, idx)] += 1
+
+    return srs_count

--- a/gecko/mutator.py
+++ b/gecko/mutator.py
@@ -448,7 +448,7 @@ def with_phonetic_replacement_table(
         arr_rule_idx = np.array([tpl[0] for tpl in arr_set_indices])
 
         # get amount of set bits per row
-        srs_set_bit_count_per_row = _dfbitlookup.count_bits_per_row(df_idx, len(phonetic_replacement_rules))
+        srs_set_bit_count_per_row = _dfbitlookup.count_bits_per_row(df_idx, len(phonetic_replacement_rules)).astype(float)
         # check which rows are not zero to avoid div by 0
         srs_count_not_zero = srs_set_bit_count_per_row != 0
 

--- a/tests/test_dfbitlookup.py
+++ b/tests/test_dfbitlookup.py
@@ -45,6 +45,18 @@ def test_set_test_index(rows: int, capacity: int, mask: pd.Series, index: int):
     assert (_dfbitlookup.test_index(df, index) == mask).all()
 
 
+def test_count_bits_per_row():
+    df = pd.DataFrame([0b1001, 0b0101, 0, 0b1101], dtype=np.uint64)
+
+    # [0] =>  1  0  0  1  => 2
+    # [1] =>  1  0  1  0  => 2
+    # [2] =>  0  0  0  0  => 0
+    # [3] =>  1  0  1  1  => 3
+
+    expected = [2, 2, 0, 3]
+    assert (_dfbitlookup.count_bits_per_row(df) == expected).all()
+
+
 def test_count_bits_per_index():
     df = pd.DataFrame([0b1001, 0b0101, 0b1101], dtype=np.uint64)
 

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -111,6 +111,25 @@ def test_with_replacement_table(rng):
     assert (srs.str.len() == srs_mut.str.len()).all()
 
 
+def test_with_replacement_table_random_values(rng):
+    srs = pd.Series(["aaa"] * 1_000)
+    df_replacement_table = pd.DataFrame.from_dict({"source": ["a", "a", "a"], "target": ["0", "1", "2"]})
+
+    mut_replacement_table = mutator.with_replacement_table(
+        df_replacement_table,
+        source_column="source",
+        target_column="target",
+        inline=True,
+        rng=rng,
+    )
+
+    (srs_mut,) = mut_replacement_table([srs], 1)
+
+    assert len(srs) == len(srs_mut)
+    assert (srs != srs_mut).all()
+    assert len(srs_mut.unique()) > 1
+
+
 def test_with_replacement_table_favor_rare_replacements(rng):
     srs = pd.Series(["foobar"] * 100 + ["foobaz"] * 50)
 
@@ -966,6 +985,25 @@ def test_with_phonetic_replacement_table(rng):
     assert not srs_mut.str.isalpha().all()
 
 
+def test_with_phonetic_replacement_table_random_values(rng):
+    srs = pd.Series(["aaa"] * 1_000)
+    df_phon = pd.DataFrame.from_dict({"source": ["a", "a", "a"], "target": ["0", "1", "2"], "flags": ["^", "_", "$"]})
+
+    mut_phonetic = mutator.with_phonetic_replacement_table(
+        df_phon,
+        source_column="source",
+        target_column="target",
+        flags_column="flags",
+        rng=rng,
+    )
+
+    (srs_mut,) = mut_phonetic([srs], 1)
+
+    assert len(srs) == len(srs_mut)
+    assert (srs != srs_mut).all()
+    assert len(srs_mut.unique()) > 1
+
+
 def test_with_phonetic_replacement_table_favor_rare_rules(rng):
     srs = pd.Series(["foobar", "foobaz", "foobat"] * 100)
     df_phon = pd.DataFrame.from_dict({"source": ["foo", "z"], "target": ["0", "1"], "flags": ["^", "$"]})
@@ -1221,6 +1259,23 @@ def test_with_regex_replacement_table_csv(rng, tmp_path):
     assert len(srs) == len(srs_mut)
     assert (srs != srs_mut).all()
     assert not srs_mut.str.isalpha().all()
+
+
+def test_with_regex_replacement_table_random_values(rng):
+    srs = pd.Series(["aaa"] * 1_000)
+    df_regex_replacement_table = pd.DataFrame.from_dict({"pattern": [".(a).", ".(a).", ".(a)."], "1": ["0", "1", "2"]})
+
+    mut_regex_replacement_table = mutator.with_regex_replacement_table(
+        df_regex_replacement_table,
+        pattern_column="pattern",
+        rng=rng,
+    )
+
+    (srs_mut,) = mut_regex_replacement_table([srs], 1)
+
+    assert len(srs) == len(srs_mut)
+    assert (srs != srs_mut).all()
+    assert len(srs_mut.unique()) > 1
 
 
 def test_mutate_data_frame(rng):

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1004,25 +1004,6 @@ def test_with_phonetic_replacement_table_random_values(rng):
     assert len(srs_mut.unique()) > 1
 
 
-def test_with_phonetic_replacement_table_favor_rare_rules(rng):
-    srs = pd.Series(["foobar", "foobaz", "foobat"] * 100)
-    df_phon = pd.DataFrame.from_dict({"source": ["foo", "z"], "target": ["0", "1"], "flags": ["^", "$"]})
-
-    mut_phonetic = mutator.with_phonetic_replacement_table(
-        df_phon,
-        source_column="source",
-        target_column="target",
-        flags_column="flags",
-        rng=rng,
-    )
-
-    (srs_mut,) = mut_phonetic([srs], 1)
-
-    assert len(srs) == len(srs_mut)
-    assert (srs != srs_mut).all()
-    assert (srs_mut == ["0bar", "fooba1", "0bat"] * 100).all()
-
-
 def test_with_phonetic_replacement_table_partial(rng):
     srs = pd.Series(["".join(tpl) for tpl in itertools.permutations("abc")])
     df_phon = pd.DataFrame.from_dict({"source": list("abcbcca"), "target": list("0123456"), "flags": list("^^^$$__")})

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1256,7 +1256,7 @@ def test_with_regex_replacement_table_random_values(rng):
 
     assert len(srs) == len(srs_mut)
     assert (srs != srs_mut).all()
-    assert len(srs_mut.unique()) > 1
+    assert len(srs_mut.unique()) == 3
 
 
 def test_mutate_data_frame(rng):

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1001,7 +1001,7 @@ def test_with_phonetic_replacement_table_random_values(rng):
 
     assert len(srs) == len(srs_mut)
     assert (srs != srs_mut).all()
-    assert len(srs_mut.unique()) > 1
+    assert len(srs_mut.unique()) == 3
 
 
 def test_with_phonetic_replacement_table_partial(rng):


### PR DESCRIPTION
Also fixes a critical bug in `with_phonetic_replacement_table` where rules wouldn't be correctly applied according to their flags when a pattern occurred multiple times in a value.